### PR TITLE
feat(publish): return release info object

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -62,6 +62,11 @@ const publish = async ({ extensionId, target, asset }: PluginConfig) => {
     }
     throw new AggregateError(errors)
   }
+
+  return {
+    name: "Chrome Web Store",
+    url: `https://chrome.google.com/webstore/detail/${extensionId}`,
+  }
 }
 
 export default publish


### PR DESCRIPTION
This makes semantic-release include a link to the extension in the comment that is posted on GitHub issues and PRs (example: https://github.com/sourcegraph/browser-extensions/pull/77#issuecomment-414897382)