### PR TITLE
fix: read `statusDetail` instead of `statusList`

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -55,7 +55,7 @@ const publish = async ({ extensionId, target, asset }: PluginConfig) => {
   if (!publishRes.status.includes('OK')) {
     const errors: SemanticReleaseError[] = []
     for (let i = 0; i < publishRes.status.length; i += 1) {
-      const message = publishRes.statusList[i]
+      const message = publishRes.statusDetail[i]
       const code = publishRes.status[i]
       const err = new SemanticReleaseError(message, code)
       errors.push(err)


### PR DESCRIPTION
# Pull Request

## Related issue

#41

## Description

This PR fixes #41 by reading the correct property `statusDetail` instead of `statusList`.

## Why

The correct property name seems `statusDetail` described in https://developer.chrome.com/webstore/webstore_api/items/publish

## How

I've read https://developer.chrome.com/webstore/webstore_api/items/publish and corrected the property name.

## Screenshots

```
[4:39:16 AM] [semantic-release] › ✖  An error occurred while running semantic-release: { TypeError: Cannot read property '0' of undefined
    at publish (/home/circleci/project/node_modules/semantic-release-chrome/dist/publish.js:60:44)
    at process._tickCallback (internal/process/next_tick.js:68:7) pluginName: 'semantic-release-chrome' }
{ TypeError: Cannot read property '0' of undefined
    at publish (/home/circleci/project/node_modules/semantic-release-chrome/dist/publish.js:60:44)
    at process._tickCallback (internal/process/next_tick.js:68:7) pluginName: 'semantic-release-chrome' }error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## How has this been tested

Sorry, I don't know how to test this package. If needed, please help me to test this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Documentation
- [x] Ready to be merged
- [x] My code follows the code style of this project (run `npm run ci` to be sure).
- [x] I have read the **[CONTRIBUTING](https://github.com/GabrielDuarteM/semantic-release-chrome/blob/master/CONTRIBUTING.md)** document.