### PR TITLE
feat(target): Add target local

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Verify the presence of the authentication parameters, which are set via environm
 
 - `extensionId`: **REQUIRED** parameter. The `extension id` from the webstore. For example: If the url of your extension is [https://chrome.google.com/webstore/detail/webplayer-hotkeys-shortcu/ikmkicnmahfdilneilgibeppbnolgkaf](https://chrome.google.com/webstore/detail/webplayer-hotkeys-shortcu/ikmkicnmahfdilneilgibeppbnolgkaf), then the last portion, `ikmkicnmahfdilneilgibeppbnolgkaf`, will be the `extension id`. You can also take this ID on the [developers dashboard](https://chrome.google.com/webstore/developer/dashboard), under the name `Item ID` located inside the `More info` dialog. This is used so that we can confirm that the credentials are working for the extension you are trying to publish.
 
+- `target`: Valid options are:
+  - `local`: Skips Chrome store credentials verification
+
 ### `prepare`
 
 Writes the correct version to the `manifest.json` and creates a `zip` file with everything inside the `dist` folder.
@@ -79,6 +82,7 @@ If you decide to make the draft, make sure to fill all the required fields on th
   - `default`: The extension will be publicly available to everyone. This is the default option if left blank.
   - `draft`: Uploads the extension to the webstore, but skips the publishing step.
   - `trustedTesters`: Releases the extension as a [private extension](https://support.google.com/chrome/a/answer/2663860). Defaults to `default`.
+  - `local`: Skips the publish step
 
 The `asset` parameter is parsed with Lodash template. The following variables are available: `branch`, `lastRelease`, `nextRelease` and `commits`. Search on the [plugins](https://github.com/semantic-release/semantic-release/blob/master/docs/developer-guide/plugin.md) documentation to see the type of those objects.
 

--- a/src/@types/pluginConfig.ts
+++ b/src/@types/pluginConfig.ts
@@ -3,7 +3,7 @@ interface PluginConfig {
   distFolder: string
   asset: string
   extensionId: string
-  target: 'default' | 'trustedTesters' | 'draft'
+  target: 'default' | 'trustedTesters' | 'draft' | 'local'
 }
 
 export default PluginConfig

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -12,6 +12,11 @@ const publish = async (
   { extensionId, target, asset }: PluginConfig,
   { logger, branch, lastRelease, nextRelease, commits }: Context,
 ) => {
+  if (target === 'local') {
+    logger.log('Target option is set to "local", skipping the publish step.')
+    return
+  }
+
   const {
     GOOGLE_CLIENT_ID: clientId,
     GOOGLE_CLIENT_SECRET: clientSecret,

--- a/src/verifyConditions.ts
+++ b/src/verifyConditions.ts
@@ -12,9 +12,14 @@ const createErrorEnvFile = (param: string, code: string) =>
   )
 
 const verifyConditions = async (
-  { extensionId }: PluginConfig,
+  { extensionId, target }: PluginConfig,
   { logger }: Context,
 ) => {
+  if (target === 'local') {
+    logger.log('Target option is set to "local". Skipping verification of Chrome store credentials.')
+    return
+  }
+
   const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN } =
     process.env
   const errors: Error[] = []


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

# Pull Request

## Description

This PR adds another flag to the `target` option. Namely, `target: 'local'`.  
When set, checking for environment variables is skipped in the `verifyConditions` step. As well as uploading the bundle to the Chrome store, during the `publish` step.

## Why

It is sometimes desirable to skip publishing to Chrome store, but still update the version in manifest.json and obtain the zipped bundle.
I.e. for publishing on the GitLab/Github releases page only.

## Type of change

<!-- What types of changes does your code introduce? -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Release for testing

https://www.npmjs.com/package/@pohy/semantic-release-chrome

## Checklist

<!-- Add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] My code follows the code style of this project (run `npm run ci` to be sure).

<!-- feel free to add additional comments -->
